### PR TITLE
fix variable typo in console output

### DIFF
--- a/360plugin.lua
+++ b/360plugin.lua
@@ -434,7 +434,7 @@ local switchEye = function()
 		in_flip = ''
 		mp.osd_message("Left eye",0.5)
 	end
-	print(ih_flip,h_flip)
+	print(in_flip,h_flip)
 	updateFilters()
 end
 


### PR DESCRIPTION
the console output for the variable was always "nil" before this fix