### PR TITLE
fix: bad argument to 'format' in closeCurrentLog

### DIFF
--- a/360plugin.lua
+++ b/360plugin.lua
@@ -538,7 +538,7 @@ local closeCurrentLog = function()
 
 		local closingCommandComment = string.format(
 			'ffmpeg -y -ss %s -i "%s" -to %s -copyts -filter_complex "%sv360=%s:%s:in_stereo=%s:out_stereo=%s:reset_rot=1:id_fov=%s:d_fov=%.3f:yaw=%.3f:pitch=%.3f:roll=%.3f:w=1920.0:h=1080.0:interp=cubic:h_flip=%s,setsar=sar=%.3f,sendcmd=filename=%s_3dViewHistory_%s.txt" -avoid_negative_ts make_zero -preset slower -crf 17 "%s_2d_%03d.mp4"',
-			startTime,filename,finalTimeStamp,in_flip,inputProjection,outputProjection,in_stereo,out_stereo,idfov,init_dfov,init_yaw,init_pitch,init_roll,h_flip,videofilename,fileobjectNumber,videofilename,fileobjectNumber,sarOutput
+			startTime, filename, finalTimeStamp, in_flip, inputProjection, outputProjection, in_stereo, out_stereo, idfov, init_dfov, init_yaw, init_pitch, init_roll, h_flip, sarOutput, videofilename, fileobjectNumber, videofilename, fileobjectNumber
 		)
 
 				


### PR DESCRIPTION
I've found an error trying to record a video using VR reversal conversion:

`[360plugin] Lua error: 360plugin.lua:539: bad argument #16 to 'format' (number expected, got string)`


This PR solves this issue.

Closes https://github.com/dfaker/VR-reversal/issues/29