### PR TITLE
Index of the table Projection starts at 1 not 0

### DIFF
--- a/360plugin.lua
+++ b/360plugin.lua
@@ -68,7 +68,7 @@ local inputProjections = {
 	"cylindrical",
 	"sg"
 }
-local inputProjectionInd = 0
+local inputProjectionInd = 1
 local inputProjection    = "hequirect"
 
 local outputProjections = {
@@ -76,7 +76,7 @@ local outputProjections = {
 	"sg"
 }
 
-local outputProjectionInd = 0
+local outputProjectionInd = 1
 local outputProjection    = "flat"
 
 
@@ -440,14 +440,14 @@ end
 
 
 local cycleInputProjection = function()
-	inputProjectionInd = ((inputProjectionInd+1) % (#inputProjections +1))
+	inputProjectionInd = inputProjectionInd % #inputProjections + 1
 	inputProjection    = inputProjections[inputProjectionInd]
 	mp.osd_message(string.format("Input projection: %s ",inputProjection),0.5)
 	updateFilters()
 end
 
 local cycleOutputProjection = function()
-	outputProjectionInd = ((outputProjectionInd+1) % (#outputProjections + 1))
+	outputProjectionInd = outputProjectionInd % #outputProjections + 1
 	outputProjection    = outputProjections[outputProjectionInd]
 	mp.osd_message(string.format("Output projection: %s",outputProjection),0.5)
 	updateFilters()


### PR DESCRIPTION
cycleInputProjection and cycleOutputProjection ran out of the limits of their functions:
```
[360plugin] 
[360plugin] stack traceback:
[360plugin]     [C]: in function 'format'
[360plugin]     /home/user/.config/mpv/scripts/360plugin.lua:445: in function 'fn'
[360plugin]     mp.defaults:230: in function 'fn'
[360plugin]     mp.defaults:65: in function 'handler'
[360plugin]     mp.defaults:382: in function 'handler'
[360plugin]     mp.defaults:512: in function 'call_event_handlers'
[360plugin]     mp.defaults:554: in function 'dispatch_events'
[360plugin]     mp.defaults:505: in function <mp.defaults:504>
[360plugin]     [C]: ?
[360plugin]     [C]: ?
[360plugin] Lua error: /home/user/.config/mpv/scripts/360plugin.lua:445: bad argument #2 to 'format' (string expected, got nil)
```
This patch fixed that.